### PR TITLE
🧹 remove unused annotations import in message_helper.py

### DIFF
--- a/services/ai/langgraph/utils/message_helper.py
+++ b/services/ai/langgraph/utils/message_helper.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Mapping
 
 from langchain_core.messages import BaseMessage


### PR DESCRIPTION
🎯 **What:** Removed the unused `from __future__ import annotations` import from `services/ai/langgraph/utils/message_helper.py`.
💡 **Why:** This improves code health by removing redundant code. The project target is Python 3.13, which supports the type hints used in this file natively without the future import.
✅ **Verification:** 
- Ran `ruff check` to confirm the issue was resolved.
- Created a temporary test script with mocked dependencies to verify that `normalize_langchain_messages` still works as expected.
- Verified removal of the import using `read_file`.
✨ **Result:** Cleaner and more maintainable code in `message_helper.py`.

---
*PR created automatically by Jules for task [17964549246481207325](https://jules.google.com/task/17964549246481207325) started by @tehj4ckass*