### PR TITLE
🧪 [testing improvement] Improve coverage for extract_text_content utility

### DIFF
--- a/tests/test_extract_text_content.py
+++ b/tests/test_extract_text_content.py
@@ -120,6 +120,43 @@ class TestExtractTextContent(unittest.TestCase):
 
         self.assertEqual(result, "Just a plain string")
 
+    def test_content_list_with_multiple_text_items(self):
+        mock_response = Mock(spec=["content"])
+        mock_response.content = [
+            {"type": "text", "text": "First "},
+            {"type": "text", "text": "Second"}
+        ]
+        # Current implementation of the list branch only returns the first match
+        result = extract_text_content(mock_response)
+        self.assertEqual(result, "First ")
+
+    def test_content_list_with_text_key_no_type(self):
+        mock_response = Mock(spec=["content"])
+        mock_response.content = [
+            {"text": "Text without type"}
+        ]
+        result = extract_text_content(mock_response)
+        self.assertEqual(result, "Text without type")
+
+    def test_content_is_dict(self):
+        mock_response = Mock(spec=["content"])
+        mock_response.content = {"key": "value"}
+        result = extract_text_content(mock_response)
+        # Should fall back to str(content)
+        self.assertEqual(result, str({"key": "value"}))
+
+    def test_response_no_attributes(self):
+        # response has neither content nor content_blocks
+        mock_response = Mock(spec=[])
+        result = extract_text_content(mock_response)
+        self.assertEqual(result, str(mock_response))
+
+    def test_content_list_with_non_dict_items(self):
+        mock_response = Mock(spec=["content"])
+        mock_response.content = ["string item", 123, {"text": "valid dict item"}]
+        result = extract_text_content(mock_response)
+        self.assertEqual(result, "valid dict item")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The `extract_text_content` utility in `services/ai/langgraph/nodes/tool_calling_helper.py` was missing tests for several edge cases and common input structures. This PR adds comprehensive test cases to `tests/test_extract_text_content.py` to ensure reliable extraction of text from various LLM response formats.

Scenarios now covered:
- Multiple text blocks in `content_blocks` (joining) vs `content` list (first match).
- Dictionary items in `content` list missing the `type` key but containing `text`.
- Fallback behavior when `content` is a raw dictionary.
- Robustness against non-dictionary items within the `content` list.
- Fallback to string representation when expected attributes are missing.

---
*PR created automatically by Jules for task [8927260865109002687](https://jules.google.com/task/8927260865109002687) started by @tehj4ckass*